### PR TITLE
shadowsocks导入时Mux默认为false

### DIFF
--- a/V2rayU/Scanner.swift
+++ b/V2rayU/Scanner.swift
@@ -149,6 +149,7 @@ class ImportUri {
         ssServer.password = ss.password
         ssServer.method = ss.method
         v2ray.serverShadowsocks = ssServer
+        v2ray.enableMux = false
         v2ray.serverProtocol = V2rayProtocolOutbound.shadowsocks.rawValue
         // check is valid
         v2ray.checkManualValid()


### PR DESCRIPTION
shadowsocks时如果 enableMux为true,那么ss是不能使用的