### PR TITLE
chore: 根据官方推荐, 默认关闭allowInsecure更加安全

### DIFF
--- a/V2rayU/Scanner.swift
+++ b/V2rayU/Scanner.swift
@@ -337,7 +337,7 @@ class VmessUri {
     var type: String = "none"
     var uplinkCapacity: Int = 50
     var downlinkCapacity: Int = 20
-    var allowInsecure: Bool = true
+    var allowInsecure: Bool = false
     var tlsServer: String = ""
     var mux: Bool = true
     var muxConcurrency: Int = 8

--- a/V2rayU/v2ray/V2rayConfig.swift
+++ b/V2rayU/v2ray/V2rayConfig.swift
@@ -133,7 +133,7 @@ class V2rayConfig: NSObject {
 
     // tls
     var streamTlsSecurity = "none"
-    var streamTlsAllowInsecure = true
+    var streamTlsAllowInsecure = false
     var streamTlsServerName = ""
 
     // xtls


### PR DESCRIPTION
v2fly.org明确写了allowInsecure的默认值是false：
https://www.v2fly.org/config/transport.html#tlsobject

其次，根据新型fq方式的设计初衷，安全必须是第一位的，不然也用不着很看重伪装、加密，所以allowInsecure默认false最科学。如果有人需要为了用自签证书而放弃一部分安全性，或者说增加一些被中间人攻击的风险，请自行设置true，不要默认把这种风险带给所有人。