### PR TITLE
Fix: GFWList无法从raw.githubusercontenc.com下载导致User PAC无法使用。

### DIFF
--- a/Build/pac/user-rule.txt
+++ b/Build/pac/user-rule.txt
@@ -1,2 +1,3 @@
 ! Put user rules line by line in this file.
 ! See https://adblockplus.org/en/filter-cheatsheet
+||githubusercontent.com


### PR DESCRIPTION
问题描述：[Issue#465 Pac自定义规则仍然无效](https://github.com/yanue/V2rayU/issues/465)
解决方法：添加`||githubusercontent.com`到默认User PAC规则，以便成功更新GFWList。[解决方案link](https://github.com/yanue/V2rayU/issues/465#issuecomment-848418934)
Changes to be committed:
    modified:   Build/pac/user-rule.txt