### PR TITLE
Update Info.plist, change type to string

### DIFF
--- a/V2rayU/Info.plist
+++ b/V2rayU/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<true/>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleGetInfoString</key>


### PR DESCRIPTION
bundle display name should be a string. see https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundledisplayname?language=objc