### PR TITLE
改进 TUN 路由排除与启动就绪检查

### DIFF
--- a/V2rayU/App/AppSettings.swift
+++ b/V2rayU/App/AppSettings.swift
@@ -76,6 +76,7 @@ final class AppSettings: ObservableObject {
     @Published var tunDnsChina: String = UserDefaults.get(forKey: .tunDnsChina, defaultValue: defaultBootstrapDns)
     // strict_route: 强制路由, 默认开启
     @Published var tunStrictRoute: Bool = UserDefaults.getBool(forKey: .tunStrictRoute, default: true)
+    @Published var tunRouteExcludeHosts: String = UserDefaults.get(forKey: .tunRouteExcludeHosts)
     // 网络变化/唤醒后自动重建 TUN, 默认开启
     @Published var tunAutoRebuild: Bool = UserDefaults.getBool(forKey: .tunAutoRebuild, default: true)
     @Published var tunLogLevel: V2rayLogLevel = UserDefaults.getEnum(forKey: .tunLogLevel, type: V2rayLogLevel.self, defaultValue: .warning)
@@ -167,6 +168,7 @@ final class AppSettings: ObservableObject {
         tunDnsRemote = UserDefaults.get(forKey: .tunDnsRemote, defaultValue: "1.1.1.1")
         tunDnsChina = UserDefaults.get(forKey: .tunDnsChina, defaultValue: defaultBootstrapDns)
         tunStrictRoute = UserDefaults.getBool(forKey: .tunStrictRoute, default: true)
+        tunRouteExcludeHosts = UserDefaults.get(forKey: .tunRouteExcludeHosts)
         tunAutoRebuild = UserDefaults.getBool(forKey: .tunAutoRebuild, default: true)
         tunLogLevel = UserDefaults.getEnum(forKey: .tunLogLevel, type: V2rayLogLevel.self, defaultValue: .warning)
         tunEnableIPv6 = UserDefaults.getBool(forKey: .tunEnableIPv6, default: false)
@@ -244,6 +246,7 @@ final class AppSettings: ObservableObject {
         UserDefaults.set(forKey: .tunDnsRemote, value: tunDnsRemote)
         UserDefaults.set(forKey: .tunDnsChina, value: tunDnsChina)
         UserDefaults.setBool(forKey: .tunStrictRoute, value: tunStrictRoute)
+        UserDefaults.set(forKey: .tunRouteExcludeHosts, value: tunRouteExcludeHosts)
         UserDefaults.setBool(forKey: .tunAutoRebuild, value: tunAutoRebuild)
         UserDefaults.set(forKey: .tunLogLevel, value: tunLogLevel.rawValue)
         UserDefaults.setBool(forKey: .tunEnableIPv6, value: tunEnableIPv6)
@@ -282,6 +285,7 @@ final class AppSettings: ObservableObject {
             old.tunDnsRemote != tunDnsRemote ||
             old.tunDnsChina != tunDnsChina ||
             old.tunStrictRoute != tunStrictRoute ||
+            old.tunRouteExcludeHosts != tunRouteExcludeHosts ||
             old.tunLogLevel != tunLogLevel ||
             old.tunEnableIPv6 != tunEnableIPv6 {
             needRestartV2ray = true

--- a/V2rayU/App/AppState.swift
+++ b/V2rayU/App/AppState.swift
@@ -193,7 +193,7 @@ final class AppState: ObservableObject {
             if !(await V2rayLaunch.shared.applyMode(from: oldMode)) {
                 // TUN 启动失败: 回退到旧模式, 保证 UI 与实际一致
                 runMode = oldMode
-                v2rayTurnOn = false
+                v2rayTurnOn = true
                 logger.info("switchRunMode: applyMode failed, reverted to \(oldMode.rawValue)")
             }
         } else {

--- a/V2rayU/Core/Handlers/TunConfigHandler.swift
+++ b/V2rayU/Core/Handlers/TunConfigHandler.swift
@@ -1,11 +1,100 @@
 import Foundation
 
 enum TunConfigHandler {
-    /// 同步 DNS 解析域名到 IP，空则返回 nil
-    static func resolveServerIp(from address: String) -> String? {
-        guard !address.isEmpty else { return nil }
+    private enum IPAddressKind {
+        case ipv4
+        case ipv6
+
+        var routePrefix: Int {
+            switch self {
+            case .ipv4: return 32
+            case .ipv6: return 128
+            }
+        }
+
+        var maximumPrefix: Int { routePrefix }
+    }
+
+    static func resolveRouteExcludeAddresses(from rawValue: String) -> [String] {
+        resolveRouteExcludeAddresses(from: rawValue, resolver: resolveServerIps)
+    }
+
+    static func resolveRouteExcludeAddresses(
+        from rawValue: String,
+        resolver: (String) -> [String]
+    ) -> [String] {
+        let separators = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet(charactersIn: ",;"))
+        let entries = rawValue.components(separatedBy: separators).filter { !$0.isEmpty }
+
+        var result: [String] = []
+        var seen = Set<String>()
+
+        func append(_ address: String) {
+            guard let normalized = normalizeRouteAddress(address), seen.insert(normalized).inserted else {
+                return
+            }
+            result.append(normalized)
+        }
+
+        for entry in entries {
+            if entry.contains("/") || normalizedIPAddress(entry) != nil {
+                append(entry)
+                continue
+            }
+            // getaddrinfo also accepts legacy numeric forms that sing-box rejects.
+            guard !isNonCanonicalNumericAddress(entry) else { continue }
+            resolver(entry).forEach(append)
+        }
+
+        return result
+    }
+
+    private static func normalizeRouteAddress(_ address: String) -> String? {
+        let parts = address.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 1 || parts.count == 2 else { return nil }
+
+        let host = String(parts[0])
+        guard let normalizedIP = normalizedIPAddress(host) else { return nil }
+
+        if parts.count == 2 {
+            guard let prefix = Int(parts[1]), (0 ... normalizedIP.kind.maximumPrefix).contains(prefix) else {
+                return nil
+            }
+            return "\(normalizedIP.address)/\(prefix)"
+        }
+        return "\(normalizedIP.address)/\(normalizedIP.kind.routePrefix)"
+    }
+
+    private static func normalizedIPAddress(_ address: String) -> (address: String, kind: IPAddressKind)? {
+        guard !address.contains("%") else { return nil }
+
+        var ipv4 = in_addr()
+        let ipv4Status = address.withCString { inet_pton(AF_INET, $0, &ipv4) }
+        if ipv4Status == 1 {
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            guard inet_ntop(AF_INET, &ipv4, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return (string(from: buffer), .ipv4)
+        }
+
+        var ipv6 = in6_addr()
+        let ipv6Status = address.withCString { inet_pton(AF_INET6, $0, &ipv6) }
+        if ipv6Status == 1 {
+            var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            guard inet_ntop(AF_INET6, &ipv6, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return (string(from: buffer), .ipv6)
+        }
+
+        return nil
+    }
+
+    private static func isNonCanonicalNumericAddress(_ address: String) -> Bool {
         var hints = addrinfo(
-            ai_flags: AI_NUMERICHOST, // 先试是否为 IP
+            ai_flags: AI_NUMERICHOST,
             ai_family: AF_UNSPEC,
             ai_socktype: SOCK_STREAM,
             ai_protocol: 0,
@@ -14,39 +103,58 @@ enum TunConfigHandler {
             ai_addr: nil,
             ai_next: nil
         )
-        // 如果是合法 IP，直接返回
-        var res: UnsafeMutablePointer<addrinfo>?
-        if getaddrinfo(address, nil, &hints, &res) == 0 {
-            freeaddrinfo(res)
-            return address
-        }
-        // 否则做 DNS 解析
-        hints.ai_flags = 0
-        guard getaddrinfo(address, nil, &hints, &res) == 0, let first = res else {
-            freeaddrinfo(res)
-            return nil
+        var result: UnsafeMutablePointer<addrinfo>?
+        let status = getaddrinfo(address, nil, &hints, &result)
+        if let result { freeaddrinfo(result) }
+        return status == 0
+    }
+
+    private static func string(from buffer: [CChar]) -> String {
+        String(decoding: buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    }
+
+    private static func resolveServerIps(from address: String) -> [String] {
+        guard !address.isEmpty else { return [] }
+        var hints = addrinfo(
+            ai_flags: 0,
+            ai_family: AF_UNSPEC,
+            ai_socktype: SOCK_STREAM,
+            ai_protocol: 0,
+            ai_addrlen: 0,
+            ai_canonname: nil,
+            ai_addr: nil,
+            ai_next: nil
+        )
+        var result: UnsafeMutablePointer<addrinfo>?
+        guard getaddrinfo(address, nil, &hints, &result) == 0, let first = result else {
+            if let result { freeaddrinfo(result) }
+            return []
         }
         defer { freeaddrinfo(first) }
-        var ip: String?
+
+        var addresses: [String] = []
+        var seen = Set<String>()
         for ptr in sequence(first: first, next: { $0.pointee.ai_next }) {
             guard let addr = ptr.pointee.ai_addr else { continue }
+            var ip: String?
             if addr.pointee.sa_family == AF_INET {
                 addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { sin in
                     var str = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
                     inet_ntop(AF_INET, &sin.pointee.sin_addr, &str, socklen_t(INET_ADDRSTRLEN))
-                    ip = String(cString: str)
+                    ip = string(from: str)
                 }
-                break
             } else if addr.pointee.sa_family == AF_INET6 {
                 addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { sin6 in
                     var str = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
                     inet_ntop(AF_INET6, &sin6.pointee.sin6_addr, &str, socklen_t(INET6_ADDRSTRLEN))
-                    ip = String(cString: str)
+                    ip = string(from: str)
                 }
-                break
+            }
+            if let ip, seen.insert(ip).inserted {
+                addresses.append(ip)
             }
         }
-        return ip
+        return addresses
     }
 
     static func buildTunConfig() -> String {
@@ -72,6 +180,8 @@ enum TunConfigHandler {
         let tunMtu = UserDefaults.getInt(forKey: .tunMtu, defaultValue: 1500)
         let tunStack = UserDefaults.getEnum(forKey: .tunStack, type: TunStack.self, defaultValue: .system)
         let tunStrictRoute = UserDefaults.getBool(forKey: .tunStrictRoute, default: true)
+        let tunRouteExcludeHosts = UserDefaults.get(forKey: .tunRouteExcludeHosts)
+        let routeExcludeAddresses = resolveRouteExcludeAddresses(from: tunRouteExcludeHosts)
         let tunEnableIPv6 = UserDefaults.getBool(forKey: .tunEnableIPv6, default: true)
         let useSniffRuleAction = SingboxVersionCheck.supportsSniffRuleAction()
 
@@ -85,6 +195,7 @@ enum TunConfigHandler {
             address: addresses,
             auto_route: true,
             strict_route: tunStrictRoute,
+            route_exclude_address: routeExcludeAddresses.isEmpty ? nil : routeExcludeAddresses,
             mtu: tunMtu,
             stack: tunStack.rawValue,
             sniff: useSniffRuleAction ? nil : true,

--- a/V2rayU/Core/Handlers/V2rayLaunch.swift
+++ b/V2rayU/Core/Handlers/V2rayLaunch.swift
@@ -66,6 +66,23 @@ enum RunMode: String, CaseIterable {
 // MARK: - 核心启动器
 actor V2rayLaunch {
     static let shared = V2rayLaunch()
+    private static let tunBackendReadyTimeout: TimeInterval = 12
+
+    enum TunStartResult: Equatable {
+        case started
+        case backendUnavailable
+        case daemonFailed
+    }
+
+    static func startTunWhenBackendReady(
+        waitForBackend: @Sendable () async -> Bool,
+        startDaemon: @Sendable () async -> Bool
+    ) async -> TunStartResult {
+        guard await waitForBackend() else {
+            return .backendUnavailable
+        }
+        return await startDaemon() ? .started : .daemonFailed
+    }
 
     /// 当前是否处于"已启动"状态（核心已拉起）。唯一的运行状态来源。
     private var running = false
@@ -187,7 +204,14 @@ actor V2rayLaunch {
             return true
         }
         if newMode == .tun && oldMode != .tun {
-            if !(await startTun()) {
+            switch await startTunWhenBackendReady() {
+            case .started:
+                break
+            case .backendUnavailable:
+                await noticeLocalized(title: .StartFailed, message: .SocksPortNotReadyForTun)
+                logger.info("applyMode: TUN backend unavailable, reverting")
+                return false
+            case .daemonFailed:
                 await notifyTunFailed()
                 logger.info("applyMode: TUN start failed, reverting")
                 return false
@@ -224,7 +248,7 @@ actor V2rayLaunch {
             return await startAll()
         }
         await stopTun()
-        let ok = await startTun()
+        let ok = await startTunWhenBackendReady() == .started
         logger.info("rebuildTun done: \(ok.description)")
         return ok
     }
@@ -244,8 +268,14 @@ actor V2rayLaunch {
 
         let mode = await MainActor.run { AppState.shared.runMode }
         if mode == .tun {
-            // TUN 不依赖 SOCKS 端口就绪(sing-box 会自行重连上游), 立即启动, 不等待 SOCKS。
-            if !(await startTun()) {
+            switch await startTunWhenBackendReady() {
+            case .started:
+                break
+            case .backendUnavailable:
+                await noticeLocalized(title: .StartFailed, message: .SocksPortNotReadyForTun)
+                await stopAll()
+                return false
+            case .daemonFailed:
                 await notifyTunFailed()
                 // TUN 启动失败: 整体回滚, 避免状态不一致
                 await stopAll()
@@ -340,7 +370,10 @@ actor V2rayLaunch {
         // 停止旧核心
         await LaunchAgent.shared.stopAgent()
         // 等待旧核心释放 SOCKS 端口（避免新核心 bind 失败）
-        _ = await waitForLocalTCPReleased(port: getEffectiveSocksProxyPort(), timeout: 2)
+        guard await waitForLocalTCPReleased(port: getEffectiveSocksProxyPort(), timeout: 2) else {
+            await noticeLocalized(title: .StartFailed, message: .LocalProxyPortNotReady)
+            return nil
+        }
 
         createJsonFile(item: item)
 
@@ -356,8 +389,7 @@ actor V2rayLaunch {
             return nil
         }
 
-        // 注意: 这里不再等待 SOCKS 端口就绪。是否等待由调用方按模式决定:
-        // TUN 模式不依赖 SOCKS(sing-box 自行重连上游), 非 TUN 模式才在设系统代理前尽力等。
+        // 这里不等待 SOCKS 端口。调用方必须在启用 TUN 或系统代理前按模式协调就绪状态。
         // 后台统计 + ping（非关键, 不阻塞）
         Task {
             await CoreTrafficStatsHandler.shared.startTask(coreType: coreDecision.coreType)
@@ -427,7 +459,10 @@ actor V2rayLaunch {
         await CoreTrafficStatsHandler.shared.resetData()
 
         await LaunchAgent.shared.stopAgent()
-        _ = await waitForLocalTCPReleased(port: getEffectiveSocksProxyPort(), timeout: 2)
+        guard await waitForLocalTCPReleased(port: getEffectiveSocksProxyPort(), timeout: 2) else {
+            await noticeLocalized(title: .StartFailed, message: .LocalProxyPortNotReady)
+            return nil
+        }
 
         createJsonFile(combination: resolved)
         truncateLogFile(appLogFilePath)
@@ -440,7 +475,7 @@ actor V2rayLaunch {
             return nil
         }
 
-        // 同 prepareAndStartCore: 不在此等待 SOCKS, 由调用方按模式决定。
+        // 同 prepareAndStartCore: 不在此等待 SOCKS, 由调用方在启用下游转发前协调。
         Task {
             await CoreTrafficStatsHandler.shared.startTask(coreType: resolved.coreType)
         }
@@ -451,7 +486,28 @@ actor V2rayLaunch {
 
     // MARK: - TUN（守护进程 + DNS）
 
-    /// 重写 tun.json、启动 TUN 守护进程、设置防污染 DNS。尽力而为, 失败仅记录日志。
+    private func startTunWhenBackendReady() async -> TunStartResult {
+        let port = getEffectiveSocksProxyPort()
+        let result = await Self.startTunWhenBackendReady(
+            waitForBackend: {
+                await self.waitForLocalTCPReady(
+                    port: port,
+                    timeout: Self.tunBackendReadyTimeout
+                )
+            },
+            startDaemon: {
+                await self.startTun()
+            }
+        )
+        if result == .backendUnavailable {
+            logger.warning(
+                "startTun: SOCKS port \(port) not ready after \(Self.tunBackendReadyTimeout)s; TUN not started"
+            )
+        }
+        return result
+    }
+
+    /// 重写 tun.json、启动 TUN 守护进程、设置防污染 DNS。调用前必须确认 SOCKS 已就绪。
     private func startTun() async -> Bool {
         LogRotation.rotateSessionLog(at: tunLogFilePath)
         LogRotation.rotateSessionLog(at: runTunLogFilePath)
@@ -512,7 +568,7 @@ actor V2rayLaunch {
             }
             try? await Task.sleep(nanoseconds: 200_000_000)
         }
-        logger.info("waitForLocalTCPReleased: port \(port) still occupied after \(timeout)s, proceeding anyway")
+        logger.warning("waitForLocalTCPReleased: port \(port) still occupied after \(timeout)s")
         return false
     }
 

--- a/V2rayU/Core/Protocols/SingBox/SingBoxConfig.swift
+++ b/V2rayU/Core/Protocols/SingBox/SingBoxConfig.swift
@@ -72,6 +72,7 @@ struct SingboxInbound: Codable {
     var address: [String]?
     var auto_route: Bool?
     var strict_route: Bool?
+    var route_exclude_address: [String]?
     var mtu: Int?
     var stack: String?  // 对 tun 需要: system
     var sniff: Bool? // 对 tun 需要

--- a/V2rayU/Localization/LanguageLabel.swift
+++ b/V2rayU/Localization/LanguageLabel.swift
@@ -129,6 +129,8 @@ enum LanguageLabel: String, CaseIterable {
     case TunChinaDns
     case TunStrictRoute
     case TunStrictRouteTip
+    case TunRouteExcludeHosts
+    case TunRouteExcludeHostsTip
     case TunAutoRebuild
     case TunAutoRebuildTip
     case TunLogLevel

--- a/V2rayU/Localization/Locales/en.lproj/Localizable.strings
+++ b/V2rayU/Localization/Locales/en.lproj/Localizable.strings
@@ -761,6 +761,8 @@ To enable Tun mode: Click the V2rayU icon in the menu bar -> Select Tun mode, or
 "TunChinaDns" = "Tun China DNS";
 "TunStrictRoute" = "Strict route (strict_route)";
 "TunStrictRouteTip" = "Enabled by default. Try turning it off if the network occasionally breaks after switching networks.";
+"TunRouteExcludeHosts" = "TUN bypass destinations";
+"TunRouteExcludeHostsTip" = "Hostnames, IP addresses, and CIDRs. Hostnames are resolved whenever TUN is rebuilt; unresolved entries are skipped.";
 "TunAutoRebuild" = "Auto rebuild TUN after network changes";
 "TunAutoRebuildTip" = "Automatically rebuild the tunnel after Wi-Fi changes or wake-up to avoid broken routes.";
 "TunLogLevel" = "TUN Log Level";

--- a/V2rayU/Localization/Locales/zh-HK.lproj/Localizable.strings
+++ b/V2rayU/Localization/Locales/zh-HK.lproj/Localizable.strings
@@ -761,6 +761,8 @@
 "TunChinaDns" = "Tun 國內 DNS";
 "TunStrictRoute" = "強制路由 (strict_route)";
 "TunStrictRouteTip" = "預設開啟。網路切換後偶發斷線時可嘗試關閉";
+"TunRouteExcludeHosts" = "TUN 繞過位址";
+"TunRouteExcludeHostsTip" = "支援網域、IP 和 CIDR。每次重建 TUN 時重新解析網域，無法解析的項目會被忽略。";
 "TunAutoRebuild" = "網路變化後自動重建 TUN";
 "TunAutoRebuildTip" = "切換 Wi-Fi / 喚醒後自動重建隧道，避免路由失效導致斷線";
 "TunLogLevel" = "TUN 日誌級別";

--- a/V2rayU/Localization/Locales/zh-Hans.lproj/Localizable.strings
+++ b/V2rayU/Localization/Locales/zh-Hans.lproj/Localizable.strings
@@ -762,6 +762,8 @@
 "TunChinaDns" = "Tun 国内 DNS";
 "TunStrictRoute" = "强制路由 (strict_route)";
 "TunStrictRouteTip" = "默认开启。网络切换后偶发断网时可尝试关闭";
+"TunRouteExcludeHosts" = "TUN 绕过地址";
+"TunRouteExcludeHostsTip" = "支持域名、IP 和 CIDR。每次重建 TUN 时重新解析域名，无法解析的条目会被忽略。";
 "TunAutoRebuild" = "网络变化后自动重建 TUN";
 "TunAutoRebuildTip" = "切换 Wi-Fi / 唤醒后自动重建隧道，避免路由失效导致断网";
 "TunLogLevel" = "TUN 日志级别";

--- a/V2rayU/UI/Views/Setting/TunView.swift
+++ b/V2rayU/UI/Views/Setting/TunView.swift
@@ -6,138 +6,158 @@ struct TunView: View {
     private var labelWidth: CGFloat = 240
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(String(localized: .TunSettings))
-                .font(.headline)
-                .foregroundColor(.secondary)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(String(localized: .TunSettings))
+                    .font(.headline)
+                    .foregroundColor(.secondary)
 
-            HStack {
-                getTextLabel(label: .TunAddress, labelWidth: labelWidth)
-                TextField(String(localized: .TunAddress), text: $settings.tunAddress)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.leading, 7)
-                Spacer()
-            }
-
-            HStack {
-                getTextLabel(label: .TunMtu, labelWidth: labelWidth)
-                TextField(String(localized: .TunMtu), value: $settings.tunMtu, formatter: NumberFormatter())
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.leading, 7)
-                Spacer()
-            }
-
-            HStack {
-                getTextLabel(label: .TunStack, labelWidth: labelWidth)
-                Spacer()
-                Picker("", selection: $settings.tunStack) {
-                    ForEach(TunStack.allCases, id: \.self) { pick in
-                        Text(pick.rawValue)
-                    }
-                }
-            }
-
-            HStack {
-                getTextLabel(label: .TunLogLevel, labelWidth: labelWidth)
-                Spacer()
-                Picker("", selection: $settings.tunLogLevel) {
-                    ForEach(V2rayLogLevel.allCases, id: \.self) { pick in
-                        Text(pick.rawValue)
-                    }
-                }
-            }
-
-            HStack {
-                Toggle(isOn: $settings.tunStrictRoute) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(localized: .TunStrictRoute))
-                        Text(String(localized: .TunStrictRouteTip))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                Spacer()
-            }
-
-            HStack {
-                Toggle(isOn: $settings.tunEnableIPv6) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(localized: .TunEnableIPv6))
-                        Text(String(localized: .TunEnableIPv6Tip))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                Spacer()
-            }
-
-            HStack {
-                Toggle(isOn: $settings.tunShowIPv6Reminder) {
-                    Text(String(localized: .TunShowIPv6Reminder))
-                        .font(.subheadline)
-                        .foregroundColor(settings.tunEnableIPv6 ? .primary : .secondary)
-                }
-                .disabled(!settings.tunEnableIPv6)
-                .padding(.leading, 24)
-                Spacer()
-            }
-
-            HStack {
-                Toggle(isOn: $settings.tunAutoRebuild) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(String(localized: .TunAutoRebuild))
-                        Text(String(localized: .TunAutoRebuildTip))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-                Spacer()
-            }
-
-            Divider()
-
-            Text(String(localized: .TunDns))
-                .font(.headline)
-                .foregroundColor(.secondary)
-
-            VStack(alignment: .leading, spacing: 4) {
                 HStack {
-                    getTextLabel(label: .TunRemoteDns, labelWidth: labelWidth)
+                    getTextLabel(label: .TunAddress, labelWidth: labelWidth)
+                    TextField(String(localized: .TunAddress), text: $settings.tunAddress)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.leading, 7)
                     Spacer()
-                    Picker("", selection: $settings.tunDnsRemote) {
-                        Text("1.1.1.1 (Cloudflare)").tag("1.1.1.1")
-                        Text("8.8.8.8 (Google)").tag("8.8.8.8")
-                        Text("9.9.9.9 (Quad9)").tag("9.9.9.9")
-                        Text("208.67.222.222 (OpenDNS)").tag("208.67.222.222")
+                }
+
+                HStack {
+                    getTextLabel(label: .TunMtu, labelWidth: labelWidth)
+                    TextField(String(localized: .TunMtu), value: $settings.tunMtu, formatter: NumberFormatter())
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.leading, 7)
+                    Spacer()
+                }
+
+                HStack {
+                    getTextLabel(label: .TunStack, labelWidth: labelWidth)
+                    Spacer()
+                    Picker("", selection: $settings.tunStack) {
+                        ForEach(TunStack.allCases, id: \.self) { pick in
+                            Text(pick.rawValue)
+                        }
                     }
-                    .pickerStyle(.menu)
-                    .frame(width: 220)
                 }
-                Label(String(localized: .TunRemoteDnsTip), systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundColor(.orange)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.leading, labelWidth + 7)
-            }
 
-            HStack {
-                getTextLabel(label: .TunChinaDns, labelWidth: labelWidth)
-                TextField(String(localized: .TunChinaDns), text: $settings.tunDnsChina)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.leading, 7)
-                Spacer()
-            }
-
-            Divider()
-
-            HStack {
-                Button(String(localized: .Save)) {
-                    settings.saveSettings()
+                HStack {
+                    getTextLabel(label: .TunLogLevel, labelWidth: labelWidth)
+                    Spacer()
+                    Picker("", selection: $settings.tunLogLevel) {
+                        ForEach(V2rayLogLevel.allCases, id: \.self) { pick in
+                            Text(pick.rawValue)
+                        }
+                    }
                 }
-                .focusable(false)
+
+                HStack {
+                    Toggle(isOn: $settings.tunStrictRoute) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(String(localized: .TunStrictRoute))
+                            Text(String(localized: .TunStrictRouteTip))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    Spacer()
+                }
+
+                HStack {
+                    Toggle(isOn: $settings.tunEnableIPv6) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(String(localized: .TunEnableIPv6))
+                            Text(String(localized: .TunEnableIPv6Tip))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    Spacer()
+                }
+
+                HStack {
+                    Toggle(isOn: $settings.tunShowIPv6Reminder) {
+                        Text(String(localized: .TunShowIPv6Reminder))
+                            .font(.subheadline)
+                            .foregroundColor(settings.tunEnableIPv6 ? .primary : .secondary)
+                    }
+                    .disabled(!settings.tunEnableIPv6)
+                    .padding(.leading, 24)
+                    Spacer()
+                }
+
+                HStack {
+                    Toggle(isOn: $settings.tunAutoRebuild) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(String(localized: .TunAutoRebuild))
+                            Text(String(localized: .TunAutoRebuildTip))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    Spacer()
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: .TunRouteExcludeHosts))
+                    TextEditor(text: $settings.tunRouteExcludeHosts)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 64, maxHeight: 80)
+                        .padding(4)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(Color(nsColor: .separatorColor))
+                        }
+                    Text(String(localized: .TunRouteExcludeHostsTip))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Divider()
+
+                Text(String(localized: .TunDns))
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        getTextLabel(label: .TunRemoteDns, labelWidth: labelWidth)
+                        Spacer()
+                        Picker("", selection: $settings.tunDnsRemote) {
+                            Text("1.1.1.1 (Cloudflare)").tag("1.1.1.1")
+                            Text("8.8.8.8 (Google)").tag("8.8.8.8")
+                            Text("9.9.9.9 (Quad9)").tag("9.9.9.9")
+                            Text("208.67.222.222 (OpenDNS)").tag("208.67.222.222")
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 220)
+                    }
+                    Label(String(localized: .TunRemoteDnsTip), systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.leading, labelWidth + 7)
+                }
+
+                HStack {
+                    getTextLabel(label: .TunChinaDns, labelWidth: labelWidth)
+                    TextField(String(localized: .TunChinaDns), text: $settings.tunDnsChina)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.leading, 7)
+                    Spacer()
+                }
+
+                Divider()
+
+                HStack {
+                    Button(String(localized: .Save)) {
+                        settings.saveSettings()
+                    }
+                    .focusable(false)
+                }
             }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onDisappear {
             AppSettings.shared.saveSettings()
         }

--- a/V2rayU/Utilities/UserDefaults.swift
+++ b/V2rayU/Utilities/UserDefaults.swift
@@ -100,6 +100,8 @@ extension UserDefaults {
         case tunDnsChina
         // tun strict_route (强制路由), 默认开启; 网络切换异常时可关闭
         case tunStrictRoute
+        // hosts, IP addresses, or CIDRs that bypass the TUN route
+        case tunRouteExcludeHosts
         // tun 自动重建: 网络变化/唤醒后自动重建 TUN, 默认开启
         case tunAutoRebuild
         // tun log level

--- a/V2rayUTests/TunCompatibilityTests.swift
+++ b/V2rayUTests/TunCompatibilityTests.swift
@@ -2,6 +2,18 @@ import Foundation
 import Testing
 @testable import V2rayU
 
+private actor TunStartupRecorder {
+    private var events: [String] = []
+
+    func append(_ event: String) {
+        events.append(event)
+    }
+
+    func snapshot() -> [String] {
+        events
+    }
+}
+
 @Suite struct TunCompatibilityTests {
 
     private let configHandler = CoreConfigHandler()
@@ -14,6 +26,63 @@ import Testing
         network: .tcp,
         security: .tls
     )
+
+    @Test("TUN does not start before its SOCKS backend is ready")
+    func testTunWaitsForBackendReadiness() async {
+        let recorder = TunStartupRecorder()
+
+        let result = await V2rayLaunch.startTunWhenBackendReady(
+            waitForBackend: {
+                await recorder.append("wait")
+                return false
+            },
+            startDaemon: {
+                await recorder.append("start")
+                return true
+            }
+        )
+
+        #expect(result == .backendUnavailable)
+        #expect(await recorder.snapshot() == ["wait"])
+    }
+
+    @Test("TUN starts after its SOCKS backend is ready")
+    func testTunStartsAfterBackendIsReady() async {
+        let recorder = TunStartupRecorder()
+
+        let result = await V2rayLaunch.startTunWhenBackendReady(
+            waitForBackend: {
+                await recorder.append("wait")
+                return true
+            },
+            startDaemon: {
+                await recorder.append("start")
+                return true
+            }
+        )
+
+        #expect(result == .started)
+        #expect(await recorder.snapshot() == ["wait", "start"])
+    }
+
+    @Test("TUN reports a daemon failure after its SOCKS backend is ready")
+    func testTunReportsDaemonFailure() async {
+        let recorder = TunStartupRecorder()
+
+        let result = await V2rayLaunch.startTunWhenBackendReady(
+            waitForBackend: {
+                await recorder.append("wait")
+                return true
+            },
+            startDaemon: {
+                await recorder.append("start")
+                return false
+            }
+        )
+
+        #expect(result == .daemonFailed)
+        #expect(await recorder.snapshot() == ["wait", "start"])
+    }
 
     @Test("TUN exclusion hosts resolve to stable IP prefixes")
     func testTunRouteExcludeHostResolution() {

--- a/V2rayUTests/TunCompatibilityTests.swift
+++ b/V2rayUTests/TunCompatibilityTests.swift
@@ -15,6 +15,72 @@ import Testing
         security: .tls
     )
 
+    @Test("TUN exclusion hosts resolve to stable IP prefixes")
+    func testTunRouteExcludeHostResolution() {
+        let resolved = TunConfigHandler.resolveRouteExcludeAddresses(
+            from: """
+            vpn.example.test
+            198.51.100.20, 2001:db8::1
+            10.0.0.0/8
+            2001:0db8::3
+            127.1
+            2130706433
+            0x7f000001
+            fe80::1%lo0
+            192.0.2.1/33
+            2001:db8::1/129
+            invalid.example.test
+            """,
+            resolver: { host in
+                switch host {
+                case "vpn.example.test":
+                    return ["192.0.2.10", "2001:db8::2", "192.0.2.10"]
+                case "invalid.example.test":
+                    return []
+                default:
+                    return ["203.0.113.9"]
+                }
+            }
+        )
+
+        #expect(resolved == [
+            "192.0.2.10/32",
+            "2001:db8::2/128",
+            "198.51.100.20/32",
+            "2001:db8::1/128",
+            "10.0.0.0/8",
+            "2001:db8::3/128",
+        ])
+    }
+
+    @Test("Generated TUN config includes configured route exclusions")
+    func testTunConfigIncludesRouteExclusions() throws {
+        let key = UserDefaults.KEY.tunRouteExcludeHosts.rawValue
+        let previousValue = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let previousValue {
+                UserDefaults.standard.set(previousValue, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        UserDefaults.set(
+            forKey: .tunRouteExcludeHosts,
+            value: "192.0.2.10/32\n198.51.100.20"
+        )
+
+        let jsonText = TunConfigHandler.buildTunConfig()
+        let data = try #require(jsonText.data(using: .utf8))
+        let parsed = try JSONDecoder().decode(SingboxStruct.self, from: data)
+        let tunInbound = try #require(parsed.inbounds.first(where: { $0.type == "tun" }))
+
+        #expect(tunInbound.route_exclude_address == [
+            "192.0.2.10/32",
+            "198.51.100.20/32",
+        ])
+    }
+
     @Test("TUN config generation and check syntax across all sing-box versions")
     func testTunConfigAcrossVersions() {
         let versions = CompatibilityTestConfig.singboxVersions


### PR DESCRIPTION
## 背景

TUN 的 `auto_route` 可能把 VPN 服务端的公网路由也接管。VPN 服务端使用 DDNS 时，Wi-Fi/网络切换后解析地址可能变化，静态 IP 排除会失效。另外，如果本地 SOCKS 核心尚未监听就启动 TUN，系统流量会先进入不可用的后端，表现为短时断网或卡顿。

Closes #1680

## 改动

- 在 TUN 设置中增加路由排除输入，支持域名、IPv4/IPv6 和 CIDR，可按行或逗号分隔。
- 每次生成 `tun.json` 时重新解析域名，规范化为 `/32` 或 `/128`、去重并忽略无效值，然后写入 sing-box 的 `route_exclude_address`。
- 启动 TUN 前等待本地 SOCKS 端口就绪，区分后端未就绪与 TUN daemon 启动失败，并在失败时保持应用运行状态一致。
- 重启代理核心前确认旧 SOCKS 端口已经释放，避免新核心 bind 失败。
- 增加 DDNS 路由排除、配置生成和 TUN 启动顺序测试。

## 验证

- `xcodebuild test -project V2rayU.xcodeproj -scheme V2rayU -destination 'platform=macOS'`
- 功能分支完整运行 109 个测试：106 个通过，5 个新增 TUN 测试全部通过。
- 官方 `main` 在同一环境完整运行时存在相同的 3 个基线失败：运行时 TUN 测试缺少外部 sing-box 测试二进制，以及两个 VMess parser 并行测试断言失败。
- 工程在本机完成编译、链接和临时签名。

本 PR 不包含 core 二进制、构建产物或内部设计文档。
