### PR TITLE
Fix workspace sleep and wake notification observers

### DIFF
--- a/V2rayU/Core/Handlers/SleepManager.swift
+++ b/V2rayU/Core/Handlers/SleepManager.swift
@@ -10,10 +10,15 @@ import AppCenterAnalytics
 
 actor SystemSleepManager {
     static let shared = SystemSleepManager()
+
+    static var workspaceNotificationCenter: NotificationCenter {
+        NSWorkspace.shared.notificationCenter
+    }
     
     public func setup() {
+        let notificationCenter = Self.workspaceNotificationCenter
         // 监听系统即将睡眠的通知
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             forName: NSWorkspace.willSleepNotification,
             object: nil,
             queue: .main
@@ -26,7 +31,7 @@ actor SystemSleepManager {
         }
         
         // 监听系统唤醒的通知
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             forName: NSWorkspace.didWakeNotification,
             object: nil,
             queue: .main

--- a/V2rayUTests/SleepManagerTests.swift
+++ b/V2rayUTests/SleepManagerTests.swift
@@ -1,0 +1,17 @@
+import AppKit
+import Testing
+@testable import V2rayU
+
+@Suite struct SystemSleepManagerTests {
+    @Test("Sleep and wake observers use the workspace notification center")
+    func usesWorkspaceNotificationCenter() {
+        #expect(
+            SystemSleepManager.workspaceNotificationCenter
+                === NSWorkspace.shared.notificationCenter
+        )
+        #expect(
+            SystemSleepManager.workspaceNotificationCenter
+                !== NotificationCenter.default
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- register `NSWorkspace.willSleepNotification` and `NSWorkspace.didWakeNotification` on `NSWorkspace.shared.notificationCenter`
- keep the existing sleep cleanup and wake restart behavior unchanged
- add a regression test that locks the observer source to the workspace notification center

## Root cause

`NSWorkspace` posts workspace lifecycle notifications through its own `notificationCenter`. `SystemSleepManager` registered both observers on `NotificationCenter.default`, so the sleep and wake handlers could be skipped entirely. In TUN mode this can leave stale routes or an unhealthy proxy core after a Mac wakes from sleep.

Apple documents these notifications on `NSWorkspace.notificationCenter`: https://developer.apple.com/documentation/appkit/nsworkspace/didwakenotification

## User impact

The existing cleanup-before-sleep and full-restart-after-wake logic can now actually receive the workspace notifications it depends on. This should reduce cases where TUN mode remains disconnected after closing and reopening a MacBook lid.

## Validation

- `git diff --check`
- the changed AppKit/NotificationCenter code was type-checked with `-strict-concurrency=complete -warnings-as-errors`
- added `SystemSleepManagerTests.usesWorkspaceNotificationCenter`

The project-level `xcodebuild test` command could not run on the authoring machine because only Command Line Tools are installed; the active developer directory is not a full Xcode installation.